### PR TITLE
Add deprecation notice to prevent confusion

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,2 +1,4 @@
+**This project is deprecated. It has been transferred to the Kotlin repo at https://github.com/JetBrains/kotlin/tree/master/eval4j**
+
 eval4j is a Java byte code interpreter written in Java.
 Its primary use case is implementing expression evaluation in debuggers.


### PR DESCRIPTION
Note that your JVMLS 2014 slides point here, but the real work has been done on the eval4j module in Kotlin. It's not wise to delete this project however, because the link would be broken.
